### PR TITLE
Make AsyncWebsocketClientBuilder a bit more ergonomic.

### DIFF
--- a/examples/subscriptions.rs
+++ b/examples/subscriptions.rs
@@ -51,7 +51,7 @@ async fn main() {
 
     let (sink, stream) = connection.split();
 
-    let mut client = CynicClientBuilder::<(), _>::new()
+    let mut client = CynicClientBuilder::new()
         .build(stream, sink, async_executors::AsyncStd)
         .await
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,5 +32,4 @@ pub use client::{AsyncWebsocketClient, AsyncWebsocketClientBuilder, Error};
 pub type CynicClient<WsMessage> = AsyncWebsocketClient<graphql::Cynic, WsMessage>;
 /// A websocket client builder for the cynic graphql crate
 #[cfg(feature = "cynic")]
-pub type CynicClientBuilder<Payload, WsMessage> =
-    AsyncWebsocketClientBuilder<Payload, graphql::Cynic, WsMessage>;
+pub type CynicClientBuilder = AsyncWebsocketClientBuilder<graphql::Cynic>;


### PR DESCRIPTION
We recently added `AsyncWebsocketClientBuilder` - a builder struct that
made it easier to optionally add a payload.  This tweaks it's
implementation such that you don't have to specify a payload type when
constructing it - it now infers it when you call the payload function
(and has a default if you don't)