### PR TITLE
Add tokio example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["examples"]
 default = ["async-tungstenite", "cynic"]
 
 [dependencies]
-async_executors = { version = "0.4" }
+async_executors = { git = "https://github.com/obmarg/async_executors.git", branch = "tokio-context" }
 futures = { version = "0.3"}
 pin-project = "1"
 serde = { version = "1.0", features = ["derive"] }
@@ -29,7 +29,4 @@ async-tungstenite = { version = "0.13", optional = true }
 cynic = { version = "0.13", optional = true }
 
 [dev-dependencies]
-async-std = { version = "1.9", features = ["attributes"] }
-async-tungstenite = { version = "0.13", features = ["async-std-runtime"] }
-async_executors = { version = "0.4", features = ["async_std"] }
 insta = "1.7"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,10 +10,11 @@ edition = "2018"
 graphql-ws-client = { path = "../", features = ["cynic", "async-tungstenite"] }
 
 async-std = { version = "1.9", features = ["attributes"] }
-async-tungstenite = { version = "0.13", features = ["async-std-runtime"] }
-async_executors = { version = "0.4", features = ["async_std"] }
+async-tungstenite = { version = "0.13", features = ["async-std-runtime", "tokio-runtime"] }
+async_executors = { git = "https://github.com/obmarg/async_executors.git", branch = "tokio-context", features = ["async_std", "tokio_context"] }
 cynic = { version = "0.13" }
 futures = { version = "0.3"}
+tokio = { version = "1.6.1", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 insta = "1.7"

--- a/examples/examples/tokio.rs
+++ b/examples/examples/tokio.rs
@@ -1,0 +1,95 @@
+//! An example of using subscriptions with `graphql-ws-client` and
+//! `async-tungstenite`
+//!
+//! Talks to the the tide subscription example in `async-graphql`
+
+mod schema {
+    cynic::use_schema!("../schemas/books.graphql");
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "../schemas/books.graphql", graphql_type = "Book")]
+struct Book {
+    id: String,
+    name: String,
+    author: String,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "../schemas/books.graphql", graphql_type = "BookChanged")]
+struct BookChanged {
+    id: cynic::Id,
+    book: Option<Book>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema_path = "../schemas/books.graphql",
+    graphql_type = "SubscriptionRoot"
+)]
+struct BooksChangedSubscription {
+    books: BookChanged,
+}
+
+#[tokio::main]
+async fn main() {
+    use async_tungstenite::tungstenite::{client::IntoClientRequest, http::HeaderValue};
+    use futures::StreamExt;
+    use graphql_ws_client::CynicClientBuilder;
+
+    let mut request = "ws://localhost:8000".into_client_request().unwrap();
+    request.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        HeaderValue::from_str("graphql-transport-ws").unwrap(),
+    );
+
+    let (connection, _) = async_tungstenite::tokio::connect_async(request)
+        .await
+        .unwrap();
+
+    println!("Connected");
+
+    let (sink, stream) = connection.split();
+
+    let mut client = CynicClientBuilder::new()
+        .build(stream, sink, async_executors::TokioContext::new())
+        .await
+        .unwrap();
+
+    let mut stream = client.streaming_operation(build_query()).await;
+    println!("Running subscription apparently?");
+    while let Some(item) = stream.next().await {
+        println!("{:?}", item);
+    }
+}
+
+fn build_query() -> cynic::StreamingOperation<'static, BooksChangedSubscription> {
+    use cynic::SubscriptionBuilder;
+
+    BooksChangedSubscription::build(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn snapshot_test_menu_query() {
+        // Running a snapshot test of the query building functionality as that gives us
+        // a place to copy and paste the actual GQL we're using for running elsewhere,
+        // and also helps ensure we don't change queries by mistake
+
+        let query = build_query();
+
+        insta::assert_snapshot!(query.query);
+    }
+
+    #[test]
+    fn test_running_query() {
+        let result = run_query();
+        if result.errors.is_some() {
+            assert_eq!(result.errors.unwrap().len(), 0);
+        }
+        insta::assert_debug_snapshot!(result.data);
+    }
+}


### PR DESCRIPTION
This also pulls in a fork of async_executors that's required to get at
the TokioCurrent executor I added - hopefully this will be merged soon
and I can ditch the fork.

Fixes #21 