### PR TITLE
Improve CI somewhat 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ main, staging, trying ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
- Disable incremental builds on CI
- Disallow warnings on CI
- Use the rust-cache action to speed up builds.
- Use actions-rs/toolchain to install rust
- Use actions-rs/cargo to run the builds & tests w/ github integration
  for the results
- Split building & running the tests into two phases.