### PR TITLE
Bump async-tungstenite to 0.18 and clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
 
 cynic = { version = "1.0", optional = true }
-async-tungstenite = { version = "0.17", optional = true }
+async-tungstenite = { version = "0.18", optional = true }
 graphql_client = { version = "0.11.0", optional = true }
 
 ws_stream_wasm = { version = "0.7", optional = true }

--- a/src/client.rs
+++ b/src/client.rs
@@ -481,9 +481,7 @@ fn decode_message<T: serde::de::DeserializeOwned, WsMessage: WebsocketMessage>(
     if message.is_ping() || message.is_pong() {
         Ok(None)
     } else if message.is_close() {
-        Err(Error::Close(
-            message.error_message().unwrap_or_default(),
-        ))
+        Err(Error::Close(message.error_message().unwrap_or_default()))
     } else if let Some(s) = message.text() {
         trace!("Decoding message: {}", s);
         Ok(Some(

--- a/src/client.rs
+++ b/src/client.rs
@@ -482,7 +482,7 @@ fn decode_message<T: serde::de::DeserializeOwned, WsMessage: WebsocketMessage>(
         Ok(None)
     } else if message.is_close() {
         Err(Error::Close(
-            message.error_message().unwrap_or(String::new()).to_owned(),
+            message.error_message().unwrap_or_default(),
         ))
     } else if let Some(s) = message.text() {
         trace!("Decoding message: {}", s);


### PR DESCRIPTION
Hi, this PR bumps `async-tungstenite` to 0.18.

I've also applied a little Clippy lint. Of course, if you want me to revert something, don't hesitate to ask!