### PR TITLE
Add an integration test & update cynic to v3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- `cynic` dependency has been updated to 3
+- `graphql_client` dependency has been updated to 0.13
+- `async_tungstenite` dependency has been updated to 0.22
+
+### Bug Fixes
+
+- Updated the cynic code to support operations with variables.
+
 ## v0.4.0 - 2023-04-02
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,13 @@ pin-project-lite = { version = "0.2.7", optional = true }
 pharos = { version = "0.5.2", optional = true }
 
 [dev-dependencies]
+assert_matches = "1.5"
+async-graphql = "5.0.10"
+async-graphql-axum = "5"
+async-tungstenite = { version = "0.20", features = ["tokio-runtime"] }
+axum = "0.6"
+cynic = { version = "2.2" }
+futures-util = "0.3"
 insta = "1.11"
+tokio = { version = "1", features = ["macros"] }
+tokio-stream = { version = "0.1", features = ["sync"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ thiserror = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
 
 cynic = { version = "3", optional = true }
-async-tungstenite = { version = "0.20", optional = true }
-graphql_client = { version = "0.12.0", optional = true }
+async-tungstenite = { version = "0.22", optional = true }
+graphql_client = { version = "0.13.0", optional = true }
 
 ws_stream_wasm = { version = "0.7", optional = true }
 pin-project-lite = { version = "0.2.7", optional = true }
@@ -44,7 +44,7 @@ pharos = { version = "0.5.2", optional = true }
 assert_matches = "1.5"
 async-graphql = "5.0.10"
 async-graphql-axum = "5"
-async-tungstenite = { version = "0.20", features = ["tokio-runtime"] }
+async-tungstenite = { version = "0.22", features = ["tokio-runtime"] }
 axum = "0.6"
 cynic = { version = "3" }
 futures-util = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0"
 thiserror = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
 
-cynic = { version = "2.2", optional = true }
+cynic = { version = "3", optional = true }
 async-tungstenite = { version = "0.20", optional = true }
 graphql_client = { version = "0.12.0", optional = true }
 
@@ -46,7 +46,7 @@ async-graphql = "5.0.10"
 async-graphql-axum = "5"
 async-tungstenite = { version = "0.20", features = ["tokio-runtime"] }
 axum = "0.6"
-cynic = { version = "2.2" }
+cynic = { version = "3" }
 futures-util = "0.3"
 insta = "1.11"
 tokio = { version = "1", features = ["macros"] }

--- a/examples-wasm/Cargo.toml
+++ b/examples-wasm/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 async-std = { version = "1.9", features = ["attributes"] }
 async_executors = { version = "0.5", features = ["async_std"] }
-cynic = { version = "2.2" }
+cynic = { version = "3" }
 futures = { version = "0.3"}
 log = "0.4"
 
@@ -22,7 +22,7 @@ console_log = "0.2"
 path = "../"
 version = "0.4.0"
 default-features = false
-features = ["cynic", "ws_stream_wasm"] 
+features = ["cynic", "ws_stream_wasm"]
 
 [dev-dependencies]
 insta = "1.11"

--- a/examples-wasm/Cargo.toml
+++ b/examples-wasm/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4"
 # wasm-specific
 ws_stream_wasm = "0.7"
 wasm-bindgen = "0.2"
-console_log = "0.2"
+console_log = "1"
 
 [dependencies.graphql-ws-client]
 path = "../"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 async-std = { version = "1.9", features = ["attributes"] }
 async_executors = { version = "0.5", features = ["async_std"] }
-cynic = { version = "2.2" }
+cynic = { version = "3" }
 futures = { version = "0.3"}
 
 async-tungstenite = { version = "0.20", features = ["async-std-runtime", "tokio-runtime"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,14 +12,14 @@ async_executors = { version = "0.5", features = ["async_std"] }
 cynic = { version = "3" }
 futures = { version = "0.3"}
 
-async-tungstenite = { version = "0.20", features = ["async-std-runtime", "tokio-runtime"] }
+async-tungstenite = { version = "0.22", features = ["async-std-runtime", "tokio-runtime"] }
 tokio = { version = "1.15", features = ["rt-multi-thread", "macros"] }
 
 [dependencies.graphql-ws-client]
 path = "../"
 version = "0.4.0"
 default-features = false
-features = ["cynic", "async-tungstenite"] 
+features = ["cynic", "async-tungstenite"]
 
 
 [dev-dependencies]

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -73,9 +73,11 @@ mod cynic {
         }
     }
 
-    impl<ResponseData> GraphqlOperation for ::cynic::StreamingOperation<ResponseData>
+    impl<ResponseData, Variables> GraphqlOperation
+        for ::cynic::StreamingOperation<ResponseData, Variables>
     where
         ResponseData: serde::de::DeserializeOwned,
+        Variables: serde::Serialize,
     {
         type GenericResponse = ::cynic::GraphQlResponse<serde_json::Value>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,11 @@
 //!
 //! graphql-ws-client implements asynchronous GraphQL-over-Websocket using the
 //! [graphql-transport-ws protocol][protocol].  It tries to be websocket client,
-//! graphql client _and_ async executor and provides built in support for:
+//! graphql client _and_ async executor agnostic and provides built in support
+//! for:
 //!
 //! - [Cynic][cynic] & [Graphql-Client][graphql-client] GraphQL clients.
-//! - [async-tungstenite][async-tungstenite] as a Websocket Client.
+//! - [async-tungstenite][async-tungstenite] & [ws-stream-wasm][ws-stream-wasm] Websocket Clients .
 //! - The [async-std][async-std] & [tokio][tokio] async runtimes.
 //!
 //! If you'd like to use another client or runtime adding support should
@@ -17,6 +18,7 @@
 //! [async-tungstenite]: https://github.com/sdroege/async-tungstenite
 //! [async-std]: https://async.rs/
 //! [tokio]: https://tokio.rs/
+//! [ws-stream-wasm]: https://github.com/najamelan/ws_stream_wasm
 
 #![warn(missing_docs)]
 

--- a/tests/cynic-tests.rs
+++ b/tests/cynic-tests.rs
@@ -1,0 +1,142 @@
+#![cfg(feature = "cynic")]
+
+use std::time::Duration;
+
+use assert_matches::assert_matches;
+use tokio::time::sleep;
+
+mod subscription_server;
+
+mod schema {
+    cynic::use_schema!("schemas/books.graphql");
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+#[cynic(schema_path = "schemas/books.graphql", graphql_type = "Book")]
+#[allow(dead_code)]
+struct Book {
+    id: String,
+    name: String,
+    author: String,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+#[cynic(schema_path = "schemas/books.graphql", graphql_type = "BookChanged")]
+#[allow(dead_code)]
+struct BookChanged {
+    id: cynic::Id,
+    book: Option<Book>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema_path = "schemas/books.graphql",
+    graphql_type = "SubscriptionRoot"
+)]
+#[allow(dead_code)]
+struct BooksChangedSubscription {
+    books: BookChanged,
+}
+
+#[tokio::test]
+async fn main() {
+    use async_tungstenite::tungstenite::{client::IntoClientRequest, http::HeaderValue};
+    use futures::StreamExt;
+    use graphql_ws_client::CynicClientBuilder;
+
+    let (channel, _) = tokio::sync::broadcast::channel(10);
+
+    subscription_server::start(57432, channel.clone()).await;
+
+    sleep(Duration::from_millis(20)).await;
+
+    let mut request = "ws://localhost:57432/ws".into_client_request().unwrap();
+    request.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        HeaderValue::from_str("graphql-transport-ws").unwrap(),
+    );
+
+    let (connection, _) = async_tungstenite::tokio::connect_async(request)
+        .await
+        .unwrap();
+
+    println!("Connected");
+
+    let (sink, stream) = connection.split();
+
+    let mut client = CynicClientBuilder::new()
+        .build(stream, sink, TokioSpawner::current())
+        .await
+        .unwrap();
+
+    let stream = client.streaming_operation(build_query()).await.unwrap();
+
+    sleep(Duration::from_millis(1000)).await;
+
+    let updates = [
+        subscription_server::BookChanged {
+            id: "123".into(),
+            book: None,
+        },
+        subscription_server::BookChanged {
+            id: "456".into(),
+            book: None,
+        },
+        subscription_server::BookChanged {
+            id: "789".into(),
+            book: None,
+        },
+    ];
+
+    futures::join!(
+        async {
+            for update in &updates {
+                channel.send(update.to_owned()).unwrap();
+            }
+        },
+        async {
+            let received_updates = stream.take(updates.len()).collect::<Vec<_>>().await;
+
+            for (expected, update) in updates.iter().zip(received_updates) {
+                let update = update.unwrap();
+                assert_matches!(update.errors, None);
+                let data = update.data.unwrap();
+                assert_eq!(data.books.id.inner(), expected.id.0);
+            }
+        }
+    );
+}
+
+fn build_query() -> cynic::StreamingOperation<BooksChangedSubscription> {
+    use cynic::SubscriptionBuilder;
+
+    BooksChangedSubscription::build(())
+}
+
+impl PartialEq<subscription_server::Book> for Book {
+    fn eq(&self, other: &subscription_server::Book) -> bool {
+        self.id == other.id.0 && self.name == other.name && self.author == other.author
+    }
+}
+
+pub struct TokioSpawner(tokio::runtime::Handle);
+
+impl TokioSpawner {
+    pub fn new(handle: tokio::runtime::Handle) -> Self {
+        TokioSpawner(handle)
+    }
+
+    pub fn current() -> Self {
+        TokioSpawner::new(tokio::runtime::Handle::current())
+    }
+}
+
+impl futures::task::Spawn for TokioSpawner {
+    fn spawn_obj(
+        &self,
+        obj: futures::task::FutureObj<'static, ()>,
+    ) -> Result<(), futures::task::SpawnError> {
+        self.0.spawn(obj);
+        Ok(())
+    }
+}

--- a/tests/subscription_server/mod.rs
+++ b/tests/subscription_server/mod.rs
@@ -52,13 +52,19 @@ pub struct BookChanged {
     pub id: ID,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug, async_graphql::Enum)]
+enum MutationType {
+    Created,
+    Deleted,
+}
+
 pub struct SubscriptionRoot {
     channel: Sender<BookChanged>,
 }
 
 #[Subscription]
 impl SubscriptionRoot {
-    async fn books(&self) -> impl Stream<Item = BookChanged> {
+    async fn books(&self, _mutation_type: MutationType) -> impl Stream<Item = BookChanged> {
         println!("Subscription received");
         BroadcastStream::new(self.channel.subscribe()).filter_map(|r| async move { r.ok() })
     }

--- a/tests/subscription_server/mod.rs
+++ b/tests/subscription_server/mod.rs
@@ -1,0 +1,65 @@
+// TODO: Start a server w/ async-graphql.
+// Query that server...
+
+use async_graphql::{EmptyMutation, Object, Schema, SimpleObject, Subscription, ID};
+use async_graphql_axum::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
+use axum::{extract::Extension, routing::post, Router, Server};
+use futures_util::{Stream, StreamExt};
+use tokio::sync::broadcast::Sender;
+use tokio_stream::wrappers::BroadcastStream;
+
+pub type BooksSchema = Schema<QueryRoot, EmptyMutation, SubscriptionRoot>;
+
+pub async fn start(port: u16, channel: Sender<BookChanged>) {
+    let schema = Schema::build(QueryRoot, EmptyMutation, SubscriptionRoot { channel }).finish();
+
+    let app = Router::new()
+        .route("/", post(graphql_handler))
+        .route_service("/ws", GraphQLSubscription::new(schema.clone()))
+        .layer(Extension(schema));
+
+    tokio::spawn(async move {
+        Server::bind(&format!("127.0.0.1:{port}").parse().unwrap())
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+}
+
+async fn graphql_handler(schema: Extension<BooksSchema>, req: GraphQLRequest) -> GraphQLResponse {
+    schema.execute(req.into_inner()).await.into()
+}
+
+#[derive(SimpleObject, Debug, Clone)]
+pub struct Book {
+    pub id: ID,
+    pub name: String,
+    pub author: String,
+}
+
+pub struct QueryRoot;
+
+#[Object]
+impl QueryRoot {
+    pub async fn id(&self) -> ID {
+        "123".into()
+    }
+}
+
+#[derive(Clone, Debug, SimpleObject)]
+pub struct BookChanged {
+    pub book: Option<Book>,
+    pub id: ID,
+}
+
+pub struct SubscriptionRoot {
+    channel: Sender<BookChanged>,
+}
+
+#[Subscription]
+impl SubscriptionRoot {
+    async fn books(&self) -> impl Stream<Item = BookChanged> {
+        println!("Subscription received");
+        BroadcastStream::new(self.channel.subscribe()).filter_map(|r| async move { r.ok() })
+    }
+}


### PR DESCRIPTION
As the title says - added an integration test to make sure the cynic integration works, and then updated to v3.

We can probably copy the integration test for `graphql-client` support as well.