### PR TITLE
Simplify the implementation a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- Subscription IDs sent to the server are now just monotonic numbers rather
+  than uuids.
+- `SubscriptionStream` no longer takes `GraphqlClient` as a generic parameter
+
 ## v0.7.0 - 2024-01-03
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = ["examples", "examples-wasm"]
 default = ["async-tungstenite"]
 client-cynic = ["async-tungstenite", "cynic"]
 client-graphql-client = ["async-tungstenite", "graphql_client"]
-ws_stream_wasm = ["dep:ws_stream_wasm", "uuid/js", "no-logging", "pharos", "pin-project-lite"]
+ws_stream_wasm = ["dep:ws_stream_wasm", "no-logging", "pharos", "pin-project-lite"]
 no-logging = []
 
 [dependencies]
@@ -31,7 +31,6 @@ pin-project = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-uuid = { version = "1.0", features = ["v4"] }
 
 cynic = { version = "3", optional = true }
 async-tungstenite = { version = "0.24", optional = true }


### PR DESCRIPTION
- Removed the `sender_loop` function, replaced it with `StreamExt::forward`
- Noticed the `GraphqlClient` generic parameter on `SubscriptionStream` wasn't doing anything so got rid of it.
- Switched the subscription IDs to be integers so I could remove the `uuid` dependency.  It didn't seem worth the extra compile time for that one feature.