### PR TITLE
Implement the new API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project intends to inhere to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html), but has not yet reached 1.0 so
 all APIs might be changed.
 
+## Unreleased - xxxx-xx-xx
+
+### Breaking Changes
+
+- `Error::Close` now has a code as well as a reason.
+
 ## v0.8.0-alpha.1 - 2024-01-19
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ws_stream_wasm = ["dep:ws_stream_wasm", "no-logging", "pharos", "pin-project-lit
 no-logging = []
 
 [dependencies]
+async-trait = "0.1"
 futures = "0.3"
 log = "0.4"
 pin-project = "1"
@@ -47,7 +48,6 @@ async-graphql-axum = "5"
 async-tungstenite = { version = "0.24", features = ["tokio-runtime"] }
 axum = "0.6"
 cynic = { version = "3" }
-futures-util = "0.3"
 insta = "1.11"
 tokio = { version = "1", features = ["macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -61,9 +61,6 @@ pub enum Error {
     /// Sender shutdown error
     #[error("sender shutdown error, reason: {0}")]
     SenderShutdown(String),
-    /// Sender shutdown error
-    #[error("the connection was closed while starting an operation")]
-    ConnectionClosedWhileStarting,
 }
 
 #[derive(Serialize)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -49,7 +49,7 @@ pub enum Error {
     /// Decoding / parsing error
     #[error("message decode error, reason: {0}")]
     Decode(String),
-    /// Decoding / parsing error
+    /// Serializing error
     #[error("couldn't serialize message, reason: {0}")]
     Serializing(String),
     /// Sending error

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod protocol;
 pub mod graphql;
 pub mod websockets;
 
+mod next;
 #[cfg(feature = "ws_stream_wasm")]
 mod wasm;
 #[cfg(feature = "ws_stream_wasm")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,10 @@ mod protocol;
 pub mod graphql;
 pub mod websockets;
 
-mod next;
+// TODO: next shouldn't be public really, and shouldn't allow missing_docs
+#[allow(missing_docs)]
+pub mod next;
+
 #[cfg(feature = "ws_stream_wasm")]
 mod wasm;
 #[cfg(feature = "ws_stream_wasm")]

--- a/src/next/actor.rs
+++ b/src/next/actor.rs
@@ -1,0 +1,184 @@
+use std::{
+    collections::HashMap,
+    future::{Future, IntoFuture},
+};
+
+use futures::{channel::mpsc, future::BoxFuture, FutureExt, SinkExt, StreamExt};
+use serde_json::{json, Value};
+
+use crate::{logging::trace, protocol::Event, Error};
+
+use super::{
+    connection::{Connection, Message},
+    ConnectionCommand,
+};
+
+#[must_use]
+pub(crate) struct ConnectionActor {
+    connection: Box<dyn Connection + Send>,
+    commands: mpsc::Receiver<ConnectionCommand>,
+    operations: HashMap<usize, mpsc::Sender<Value>>,
+}
+
+impl ConnectionActor {
+    // TODO: this could be public as an alternative to IntoFuture
+    async fn run(mut self) {
+        // TODO: Do the initial ack flow?
+
+        while let Some(next) = self.next().await {
+            let response = match next {
+                Next::Command(cmd) => self.handle_command(cmd).await,
+                Next::Message(message) => self.handle_message(message).await,
+            };
+
+            if let Some(response) = response {
+                match response {
+                    response @ Message::Close { .. } => {
+                        self.connection.send(response).await.ok();
+                        return;
+                    }
+                    response => {
+                        if self.connection.send(response).await.is_err() {
+                            todo!("error handling")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_command(&mut self, cmd: ConnectionCommand) -> Option<Message> {
+        match cmd {
+            ConnectionCommand::Subscribe {
+                request,
+                sender,
+                id,
+            } => {
+                assert!(self.operations.insert(id, sender).is_none());
+
+                Some(Message::Text(request))
+            }
+            ConnectionCommand::Cancel(id) => {
+                if self.operations.remove(&id).is_some() {
+                    return Some(Message::complete(id));
+                }
+                None
+            }
+            ConnectionCommand::Close(code, reason) => Some(Message::Close {
+                code: Some(code),
+                reason: Some(reason),
+            }),
+        }
+    }
+
+    async fn handle_message(&mut self, message: Message) -> Option<Message> {
+        let event = match extract_event(message) {
+            Ok(event) => event?,
+            Err(error) => todo!(),
+        };
+
+        match event {
+            event @ (Event::Next { .. } | Event::Error { .. }) => {
+                let id = match event.id().unwrap().parse::<usize>().ok() {
+                    Some(id) => id,
+                    None => return Some(Message::close(Reason::UnknownSubscription)),
+                };
+
+                let sender = match self.operations.get_mut(&id) {
+                    Some(id) => id,
+                    None => return Some(Message::close(Reason::UnknownSubscription)),
+                };
+
+                let payload = event.forwarding_payload().unwrap();
+
+                if sender.send(payload).await.is_err() {
+                    todo!("error")
+                }
+
+                None
+            }
+            Event::Complete { id } => {
+                let id = match id.parse::<usize>().ok() {
+                    Some(id) => id,
+                    None => return Some(Message::close(Reason::UnknownSubscription)),
+                };
+
+                trace!("Stream complete");
+
+                self.operations.remove(&id);
+                None
+            }
+            Event::ConnectionAck { .. } => Some(Message::close(Reason::UnexpectedAck)),
+            Event::Ping { .. } => Some(Message::Pong),
+            Event::Pong { .. } => None,
+        }
+    }
+
+    fn next(&mut self) -> impl Future<Output = Option<Next>> + '_ {
+        let mut next_command = self.commands.next().fuse();
+        let mut next_message = self.connection.receive().fuse();
+        async move {
+            // TODO: Handle termination of these streams appropriately...
+            futures::select! {
+                command = next_command => {
+                    Some(Next::Command(command.expect("TODO: handle termination")))
+                },
+                message = next_message => {
+                    Some(Next::Message(message.expect("TODO: handle termination")))
+                },
+            }
+        }
+    }
+}
+
+enum Next {
+    Command(ConnectionCommand),
+    Message(Message),
+}
+
+impl IntoFuture for ConnectionActor {
+    type Output = ();
+
+    type IntoFuture = BoxFuture<'static, ()>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(self.run())
+    }
+}
+
+fn extract_event(message: Message) -> Result<Option<Event>, Error> {
+    match message {
+        Message::Text(s) => {
+            trace!("Decoding message: {}", s);
+            Ok(Some(
+                serde_json::from_str(&s).map_err(|err| Error::Decode(err.to_string()))?,
+            ))
+        }
+        Message::Close { code, reason } => Err(Error::Close(
+            code.unwrap_or_default(),
+            reason.unwrap_or_default(),
+        )),
+        Message::Ping | Message::Pong => Ok(None),
+    }
+}
+
+enum Reason {
+    UnexpectedAck,
+    UnknownSubscription,
+}
+
+impl Message {
+    fn close(reason: Reason) -> Self {
+        todo!()
+    }
+}
+
+impl Event {
+    fn forwarding_payload(self) -> Option<Value> {
+        match self {
+            Event::Next { id, payload } => Some(payload),
+            Event::Error { id, payload } => Some(json!({"errors": payload})),
+            _ => None,
+        }
+    }
+}

--- a/src/next/actor.rs
+++ b/src/next/actor.rs
@@ -21,10 +21,19 @@ pub(crate) struct ConnectionActor {
 }
 
 impl ConnectionActor {
+    pub(super) fn new(
+        connection: Box<dyn Connection + Send>,
+        commands: mpsc::Receiver<ConnectionCommand>,
+    ) -> Self {
+        ConnectionActor {
+            connection,
+            commands,
+            operations: HashMap::new(),
+        }
+    }
+
     // TODO: this could be public as an alternative to IntoFuture
     async fn run(mut self) {
-        // TODO: Do the initial ack flow?
-
         while let Some(next) = self.next().await {
             let response = match next {
                 Next::Command(cmd) => self.handle_command(cmd).await,

--- a/src/next/actor.rs
+++ b/src/next/actor.rs
@@ -14,7 +14,7 @@ use super::{
 };
 
 #[must_use]
-pub(crate) struct ConnectionActor {
+pub struct ConnectionActor {
     client: Option<mpsc::Receiver<ConnectionCommand>>,
     connection: Box<dyn Connection + Send>,
     operations: HashMap<usize, mpsc::Sender<Value>>,

--- a/src/next/actor.rs
+++ b/src/next/actor.rs
@@ -147,15 +147,12 @@ impl ConnectionActor {
                 let mut next_message = self.connection.receive().fuse();
                 futures::select! {
                     command = next_command => {
-                        match command {
-                            None => {
-                                self.client.take();
-                                continue;
-                            },
-                            Some(command) => {
-                                return Some(Next::Command(command));
-                            }
-                        }
+                        let Some(command) = command else {
+                            self.client.take();
+                            continue;
+                        };
+
+                        return Some(Next::Command(command));
                     },
                     message = next_message => {
                         return Some(Next::Message(message?));

--- a/src/next/builder.rs
+++ b/src/next/builder.rs
@@ -61,7 +61,7 @@ impl ClientBuilder {
 
     async fn build_impl(
         self,
-        connection: Box<dyn Connection + Send>,
+        mut connection: Box<dyn Connection + Send>,
     ) -> Result<(Client, ConnectionActor), Error> {
         connection.send(Message::init(self.payload)).await?;
 
@@ -94,7 +94,6 @@ impl ClientBuilder {
                                 code: Some(4950),
                                 reason: Some("Unexpected message while waiting for ack".into()),
                             });
-                            // TODO: Close the connection gracefully before returning...
                             return Err(Error::Decode(format!(
                                 "expected a connection_ack or ping, got {}",
                                 event.r#type()

--- a/src/next/builder.rs
+++ b/src/next/builder.rs
@@ -1,0 +1,109 @@
+use std::collections::HashMap;
+
+use futures::channel::mpsc;
+use serde::Serialize;
+
+use crate::{logging::trace, protocol::Event, Error};
+
+use super::{
+    actor::ConnectionActor,
+    connection::{Connection, Message},
+    Client,
+};
+
+/// A websocket client builder
+#[derive(Default)]
+pub struct ClientBuilder {
+    payload: Option<serde_json::Value>,
+    subscription_buffer_size: Option<usize>,
+}
+
+impl ClientBuilder {
+    /// Constructs an AsyncWebsocketClientBuilder
+    pub fn new() -> ClientBuilder {
+        ClientBuilder::default()
+    }
+
+    /// Add payload to `connection_init`
+    pub fn payload<NewPayload>(self, payload: NewPayload) -> Result<ClientBuilder, Error>
+    where
+        NewPayload: Serialize,
+    {
+        Ok(ClientBuilder {
+            payload: Some(
+                serde_json::to_value(payload)
+                    .map_err(|error| Error::Serializing(error.to_string()))?,
+            ),
+            ..self
+        })
+    }
+
+    pub fn subscription_buffer_size(self, new: usize) -> Self {
+        ClientBuilder {
+            subscription_buffer_size: Some(new),
+            ..self
+        }
+    }
+}
+
+impl ClientBuilder {
+    /// Constructs a Client
+    ///
+    /// Accepts an already built websocket connection, and returns the connection
+    /// and a future that must be awaited somewhere - if the future is dropped the
+    /// connection will also drop.
+    pub async fn build<Conn>(self, connection: Conn) -> Result<(Client, ConnectionActor), Error>
+    where
+        Conn: Connection + Send + 'static,
+    {
+        self.build_impl(Box::new(connection)).await
+    }
+
+    async fn build_impl(
+        self,
+        connection: Box<dyn Connection + Send>,
+    ) -> Result<(Client, ConnectionActor), Error> {
+        connection.send(Message::init(self.payload)).await?;
+
+        // wait for ack before entering receiver loop:
+        loop {
+            match connection.receive().await {
+                None => todo!(),
+                Some(Message::Close { code, reason }) => {
+                    todo!()
+                }
+                Some(Message::Ping) | Some(Message::Pong) => {}
+                Some(message @ Message::Text(_)) => {
+                    let event = message.deserialize::<Event>()?;
+                    match event {
+                        // pings can be sent at any time
+                        Event::Ping { .. } => {
+                            connection.send(Message::graphql_pong()).await?;
+                        }
+                        Event::Pong { .. } => {}
+                        Event::ConnectionAck { .. } => {
+                            // handshake completed, ready to enter main receiver loop
+                            trace!("connection_ack received, handshake completed");
+                            break;
+                        }
+                        event => {
+                            // TODO: Close the connection gracefully before returning...
+                            return Err(Error::Decode(format!(
+                                "expected a connection_ack or ping, got {}",
+                                event.r#type()
+                            )));
+                        }
+                    }
+                }
+            }
+        }
+
+        let (command_sender, command_receiver) = mpsc::channel(5);
+
+        let actor = ConnectionActor::new(connection, command_receiver);
+
+        let client = Client::new(command_sender, self.subscription_buffer_size.unwrap_or(5));
+
+        Ok((client, actor))
+    }
+}

--- a/src/next/connection.rs
+++ b/src/next/connection.rs
@@ -7,8 +7,8 @@ use crate::{protocol, Error};
 
 #[async_trait::async_trait]
 pub trait Connection {
-    async fn receive(&self) -> Option<Message>;
-    async fn send(&self, message: Message) -> Result<(), Error>;
+    async fn receive(&mut self) -> Option<Message>;
+    async fn send(&mut self, message: Message) -> Result<(), Error>;
 }
 
 pub enum Message {

--- a/src/next/connection.rs
+++ b/src/next/connection.rs
@@ -3,10 +3,12 @@ use std::future::Future;
 use serde::Serialize;
 use serde_json::json;
 
+use crate::{protocol, Error};
+
 #[async_trait::async_trait]
 pub trait Connection {
-    async fn receive(&self) -> Result<Message, ()>;
-    async fn send(&self, message: Message) -> Result<(), ()>;
+    async fn receive(&self) -> Option<Message>;
+    async fn send(&self, message: Message) -> Result<(), Error>;
 }
 
 pub enum Message {
@@ -20,6 +22,28 @@ pub enum Message {
 }
 
 impl Message {
+    pub(crate) fn deserialize<T>(self) -> Result<T, Error>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let Message::Text(text) = self else {
+            panic!("Don't call deserialize on non-text messages");
+        };
+
+        serde_json::from_str(&text).map_err(|error| Error::Decode(error.to_string()))
+    }
+
+    pub(crate) fn init(payload: Option<serde_json::Value>) -> Self {
+        Self::Text(
+            serde_json::to_string(&crate::protocol::ConnectionInit::new(payload))
+                .expect("payload is already serialized so this shouldn't fail"),
+        )
+    }
+
+    pub(crate) fn graphql_pong() -> Self {
+        Self::Text(serde_json::to_string(&crate::protocol::Message::Pong::<()>).unwrap())
+    }
+
     pub(crate) fn complete(id: usize) -> Self {
         Self::Text(
             serde_json::to_string(&crate::protocol::Message::Complete::<()> { id: id.to_string() })

--- a/src/next/connection.rs
+++ b/src/next/connection.rs
@@ -1,0 +1,29 @@
+use std::future::Future;
+
+use serde::Serialize;
+use serde_json::json;
+
+#[async_trait::async_trait]
+pub trait Connection {
+    async fn receive(&self) -> Result<Message, ()>;
+    async fn send(&self, message: Message) -> Result<(), ()>;
+}
+
+pub enum Message {
+    Text(String),
+    Close {
+        code: Option<u16>,
+        reason: Option<String>,
+    },
+    Ping,
+    Pong,
+}
+
+impl Message {
+    pub(crate) fn complete(id: usize) -> Self {
+        Self::Text(
+            serde_json::to_string(&crate::protocol::Message::Complete::<()> { id: id.to_string() })
+                .unwrap(),
+        )
+    }
+}

--- a/src/next/mod.rs
+++ b/src/next/mod.rs
@@ -83,13 +83,11 @@ impl Client {
         })
     }
 
-    // TODO: This should be on the stream itself
-    // pub fn cancel(&self) -> () {
-    //     todo!()
-    // }
-
-    pub fn close(&self) {
-        todo!()
+    pub async fn close(mut self, code: u16, description: impl Into<String>) {
+        self.actor
+            .send(ConnectionCommand::Close(code, description.into()))
+            .await
+            .ok();
     }
 }
 

--- a/src/next/mod.rs
+++ b/src/next/mod.rs
@@ -1,0 +1,91 @@
+use std::sync::{
+    atomic::{AtomicU64, AtomicUsize, Ordering},
+    Arc,
+};
+
+use futures::{
+    channel::{mpsc, oneshot},
+    SinkExt, StreamExt,
+};
+use serde_json::Value;
+
+use crate::{
+    graphql::GraphqlOperation,
+    protocol::{self, Message},
+    Error,
+};
+
+use self::stream::SubscriptionStream;
+
+mod actor;
+mod connection;
+mod stream;
+
+pub struct Client {
+    actor: mpsc::Sender<ConnectionCommand>,
+    subscription_buffer_size: usize,
+    next_id: Arc<AtomicUsize>,
+}
+
+impl Client {
+    // Starts a streaming operation on this client.
+    ///
+    /// Returns a `Stream` of responses.
+    pub async fn streaming_operation<'a, Operation>(
+        &mut self,
+        op: Operation,
+    ) -> Result<SubscriptionStream<Operation>, Error>
+    where
+        Operation: GraphqlOperation + Unpin + Send + 'static,
+    {
+        let (sender, receiver) = mpsc::channel(self.subscription_buffer_size);
+
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+
+        let message = protocol::Message::Subscribe {
+            id: id.to_string(),
+            payload: &op,
+        };
+
+        let request = serde_json::to_string(&message)
+            .map_err(|error| Error::Serializing(error.to_string()))?;
+
+        self.actor
+            .send(ConnectionCommand::Subscribe {
+                request,
+                sender,
+                id,
+            })
+            .await
+            .map_err(|error| Error::Send(error.to_string()))?;
+
+        Ok(SubscriptionStream::<Operation> {
+            id,
+            stream: Box::pin(receiver.map(move |response| {
+                op.decode(response)
+                    .map_err(|err| Error::Decode(err.to_string()))
+            })),
+            actor: self.actor.clone(),
+        })
+    }
+
+    // TODO: This should be on the stream itself
+    // pub fn cancel(&self) -> () {
+    //     todo!()
+    // }
+
+    pub fn close(&self) -> () {
+        todo!()
+    }
+}
+
+pub(super) enum ConnectionCommand {
+    Subscribe {
+        /// The full subscribe request as a JSON encoded string.
+        request: String,
+        sender: mpsc::Sender<Value>,
+        id: usize,
+    },
+    Cancel(usize),
+    Close(u16, String),
+}

--- a/src/next/mod.rs
+++ b/src/next/mod.rs
@@ -18,6 +18,7 @@ use crate::{
 use self::stream::SubscriptionStream;
 
 mod actor;
+mod builder;
 mod connection;
 mod stream;
 
@@ -28,6 +29,17 @@ pub struct Client {
 }
 
 impl Client {
+    pub(super) fn new(
+        actor: mpsc::Sender<ConnectionCommand>,
+        subscription_buffer_size: usize,
+    ) -> Self {
+        Client {
+            actor,
+            subscription_buffer_size,
+            next_id: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
     // Starts a streaming operation on this client.
     ///
     /// Returns a `Stream` of responses.

--- a/src/next/mod.rs
+++ b/src/next/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unused)] // TEMPORARY
+
 use std::sync::{
     atomic::{AtomicU64, AtomicUsize, Ordering},
     Arc,
@@ -86,7 +88,7 @@ impl Client {
     //     todo!()
     // }
 
-    pub fn close(&self) -> () {
+    pub fn close(&self) {
         todo!()
     }
 }

--- a/src/next/mod.rs
+++ b/src/next/mod.rs
@@ -13,16 +13,21 @@ use serde_json::Value;
 
 use crate::{
     graphql::GraphqlOperation,
-    protocol::{self, Message},
+    protocol::{self},
     Error,
 };
-
-use self::stream::SubscriptionStream;
 
 mod actor;
 mod builder;
 mod connection;
 mod stream;
+
+pub use self::{
+    actor::ConnectionActor,
+    builder::ClientBuilder,
+    connection::{Connection, Message},
+    stream::SubscriptionStream,
+};
 
 pub struct Client {
     actor: mpsc::Sender<ConnectionCommand>,

--- a/src/next/stream.rs
+++ b/src/next/stream.rs
@@ -7,7 +7,7 @@ use futures::{channel::mpsc, SinkExt, Stream};
 
 use crate::{graphql::GraphqlOperation, Error};
 
-use super::ConnectionCommand;
+use super::{actor::ConnectionActor, ConnectionCommand};
 
 /// A `futures::Stream` for a subscription.
 ///

--- a/src/next/stream.rs
+++ b/src/next/stream.rs
@@ -31,7 +31,7 @@ where
         self.actor
             .send(ConnectionCommand::Cancel(self.id))
             .await
-            .map_err(|error| todo!())
+            .map_err(|error| Error::Send(error.to_string()))
     }
 }
 

--- a/src/next/stream.rs
+++ b/src/next/stream.rs
@@ -1,0 +1,47 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{channel::mpsc, SinkExt, Stream};
+
+use crate::{graphql::GraphqlOperation, Error};
+
+use super::ConnectionCommand;
+
+/// A `futures::Stream` for a subscription.
+///
+/// Emits an item for each message received by the subscription.
+#[pin_project::pin_project]
+pub struct SubscriptionStream<Operation>
+where
+    Operation: GraphqlOperation,
+{
+    pub(super) id: usize,
+    pub(super) stream: Pin<Box<dyn Stream<Item = Result<Operation::Response, Error>> + Send>>,
+    pub(super) actor: mpsc::Sender<ConnectionCommand>,
+}
+
+impl<Operation> SubscriptionStream<Operation>
+where
+    Operation: GraphqlOperation + Send,
+{
+    /// Stops the operation by sending a Complete message to the server.
+    pub async fn stop_operation(mut self) -> Result<(), Error> {
+        self.actor
+            .send(ConnectionCommand::Cancel(self.id))
+            .await
+            .map_err(|error| todo!())
+    }
+}
+
+impl<Operation> Stream for SubscriptionStream<Operation>
+where
+    Operation: GraphqlOperation + Unpin,
+{
+    type Item = Result<Operation::Response, Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().stream.as_mut().poll_next(cx)
+    }
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -38,7 +38,6 @@ pub enum Message<'a, Operation> {
     #[serde(rename = "subscribe")]
     Subscribe { id: String, payload: &'a Operation },
     #[serde(rename = "complete")]
-    #[allow(dead_code)]
     Complete { id: String },
     #[serde(rename = "pong")]
     Pong,

--- a/tests/subscription_server/mod.rs
+++ b/tests/subscription_server/mod.rs
@@ -4,7 +4,7 @@
 use async_graphql::{EmptyMutation, Object, Schema, SimpleObject, Subscription, ID};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
 use axum::{extract::Extension, routing::post, Router, Server};
-use futures_util::{Stream, StreamExt};
+use futures::{Stream, StreamExt};
 use tokio::sync::broadcast::Sender;
 use tokio_stream::wrappers::BroadcastStream;
 


### PR DESCRIPTION
As outlined in #59 - I'm not happy with the current API.

This PR introduces most of the new API I want to support - this is basically ended up as a rewrite rather than the refactor I'd intended.  But that has some advantages - I'm probably going to release v0.8.0 with the old API still intact but marked as deprecated.  I think this might provide a nicer update experience than being faced with an immediate wall of compiler errors.

Future PRs will continue with the rest of the work.