### PR TITLE
Don't mark the entire legacy module as deprecated

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@ mod logging;
 mod protocol;
 
 #[doc(hidden)]
-#[deprecated]
 pub mod legacy;
 
 #[doc(hidden)]


### PR DESCRIPTION
I tried upgrading a project and it was just too noisy.  Was hard to spot the important bits to change in amongst all the noise.