### PR TITLE
Add rust-version to Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ all APIs might be changed.
 - `async_tungstenite` is no longer a default feautre, you should explicitly
   enable it if you need it
 - Updated to `async_tungstenite` 0.25
+- MSRV is now 1.69 (there was no official MSRV before)
 
 ### Deprecations
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ autoexamples = false
 documentation = "https://docs.rs/graphql-ws-client"
 readme = "README.md"
 repository = "https://github.com/obmarg/graphql-ws-client"
+rust-version = "1.69"
 
 [workspace]
 members = ["examples", "examples-wasm"]


### PR DESCRIPTION
I'm not sure precisely which MSRV graphql-ws-client _really_ has, but I'm setting 1.69 in the `Cargo.toml` mostly as a goal & documentation of that goal.