### PR TITLE
chore: add release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,14 @@
+[workspace]
+changelog_update = false
+git_release_enable = false
+git_tag_enable = false
+
+[[package]]
+name = "graphql-ws-client"
+
+git_tag_name = "v{{version}}"
+git_tag_enable = true
+git_release_enable = true
+
+changelog_update = true
+changelog_path = "./CHANGELOG.md"


### PR DESCRIPTION
I wanted to use release-plz without config in this repo, but it seems like it doesn't pay attention to `publish = "false"` when determining whether or not there's a single public crate in the workspace.

This was leading to it not using my preferred scheme for release tags.  I'd maybe like to fix upstream but for now it is far easier to just configure it.