### PR TITLE
fix: make client clone, remove &mut self from subscribe

### DIFF
--- a/examples-wasm/examples/subscriptions.rs
+++ b/examples-wasm/examples/subscriptions.rs
@@ -57,7 +57,7 @@ async fn main() {
 
     let connection = Connection::new(ws_conn).await;
 
-    let (mut client, actor) = Client::build(connection).await.unwrap();
+    let (client, actor) = Client::build(connection).await.unwrap();
     wasm_bindgen_futures::spawn_local(actor.into_future());
 
     let mut stream = client.subscribe(build_query()).await.unwrap();

--- a/examples/examples/cynic-mulitiple-subscriptions.rs
+++ b/examples/examples/cynic-mulitiple-subscriptions.rs
@@ -55,7 +55,7 @@ async fn main() {
 
     println!("Connected");
 
-    let (mut client, actor) = Client::build(connection).await.unwrap();
+    let (client, actor) = Client::build(connection).await.unwrap();
     async_std::task::spawn(actor.into_future());
 
     // In reality you'd probably want to different subscriptions, but for the sake of this example

--- a/examples/examples/tokio.rs
+++ b/examples/examples/tokio.rs
@@ -54,7 +54,7 @@ async fn main() {
 
     println!("Connected");
 
-    let (mut client, actor) = Client::build(connection).await.unwrap();
+    let (client, actor) = Client::build(connection).await.unwrap();
     tokio::spawn(actor.into_future());
 
     let mut stream = client.subscribe(build_query()).await.unwrap();

--- a/src/next/builder.rs
+++ b/src/next/builder.rs
@@ -105,7 +105,7 @@ impl ClientBuilder {
     where
         Operation: GraphqlOperation + Unpin + Send + 'static,
     {
-        let (mut client, actor) = self.await?;
+        let (client, actor) = self.await?;
 
         let mut actor_future = actor.into_future().fuse();
 

--- a/tests/cynic-tests.rs
+++ b/tests/cynic-tests.rs
@@ -72,7 +72,7 @@ async fn main_test() {
 
     println!("Connected");
 
-    let (mut client, actor) = graphql_ws_client::Client::build(connection).await.unwrap();
+    let (client, actor) = graphql_ws_client::Client::build(connection).await.unwrap();
 
     tokio::spawn(actor.into_future());
 

--- a/tests/graphql-client-tests.rs
+++ b/tests/graphql-client-tests.rs
@@ -37,7 +37,7 @@ async fn main_test() {
 
     println!("Connected");
 
-    let (mut client, actor) = graphql_ws_client::Client::build(connection).await.unwrap();
+    let (client, actor) = graphql_ws_client::Client::build(connection).await.unwrap();
 
     tokio::spawn(actor.into_future());
 


### PR DESCRIPTION
In #87 a user was having issues using graphql-ws-client in a multithreaded environment.  These issues stemmed from:

1. As `Client::subscribe` takes `&mut self` they needed a `Arc<RwLock<Client>>`, which is a bit annoying.
2. They want to call `Client::close` at some point, which takes an owned `Client` and it's hard to get one of those when you're sharing the client among many threads.

This fixes 1 by removing the mutability from `Client::subscribe` and 2 by driving `Clone` on `Client`.  

If a user has cloned the `Client` and they call `close` on one instance it'll close all the others.  So any future calls to `Client::subscribe` on those other clients will fail.  Not ideal, but I think it's reasonable to expect users to handle this case if they have a need to clone the Client.