### PR TITLE
chore: release-plz config tweaks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,9 @@ env:
 
 jobs:
   check-format:
+    # Skip draft release PRs
+    if: ${{ github.actor_id != '166155226' || github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -28,6 +31,9 @@ jobs:
           args: -- --check
 
   build:
+    # Skip draft release PRs
+    if: ${{ github.actor_id != '166155226' || github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+
     runs-on: ubuntu-latest
 
     steps:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,6 +3,28 @@ changelog_update = false
 git_release_enable = false
 git_tag_enable = false
 
+# create the release PR in draft to avoid running CI till we're ready
+pr_draft = true
+
+[changelog] 
+commit_parsers = [
+    { message = "^feat!", group = "<!-- 0 -->Breaking Changes" },
+    { message = "^feat", group = "<!-- 1 -->New Features" },
+    { message = "^fix", group = "<!-- 2 -->Bug Fixes" },
+    { message = "^chore", group = "<!-- 3 -->Changes" },
+]
+body = """
+
+## v{{ version }} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+
+{% for commit in commits -%}
+- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}
+{% endfor -%}
+{% endfor -%}
+"""
+
 [[package]]
 name = "graphql-ws-client"
 


### PR DESCRIPTION
This makes the changelog generated by release-plz _slightly_ closer to what I'd do by hand.  Not perfect, but better.

Also disable CI for draft release PRs.