### PR TITLE
chore(deps): update deps to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0f8d64ef9351752fbe5462f242c625d9c4910d2bc3f7ec44c43857ca123f5d"
+checksum = "67824e7945b9a2bf2057a363ab01b103e3217962afe0f3b789e6df8b13ac0a86"
 dependencies = [
  "async-std",
  "futures-io",
@@ -328,22 +328,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
- "tungstenite",
-]
-
-[[package]]
-name = "async_executors"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0b8626a279ab86ef8ba31cc91549e3386eb7883cd94305896d438aa6535c62"
-dependencies = [
- "async-std",
- "blanket 0.2.0",
- "futures-core",
- "futures-task",
- "futures-util",
- "pin-project",
- "rustc_version",
+ "tungstenite 0.23.0",
 ]
 
 [[package]]
@@ -353,7 +338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a982d2f86de6137cc05c9db9a915a19886c97911f9790d04f174cede74be01a5"
 dependencies = [
  "async-std",
- "blanket 0.3.0",
+ "blanket",
  "futures-core",
  "futures-task",
  "futures-util",
@@ -492,17 +477,6 @@ name = "bitflags"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
-
-[[package]]
-name = "blanket"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b04ce3d2372d05d1ef4ea3fdf427da6ae3c17ca06d688a107b5344836276bc3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "blanket"
@@ -845,7 +819,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "async-tungstenite",
- "async_executors 0.7.0",
+ "async_executors",
  "cynic",
  "futures",
  "graphql-ws-client",
@@ -860,7 +834,7 @@ name = "examples-wasm"
 version = "0.1.0"
 dependencies = [
  "async-std",
- "async_executors 0.5.1",
+ "async_executors",
  "console_log",
  "cynic",
  "futures",
@@ -1105,15 +1079,15 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tungstenite",
+ "tungstenite 0.23.0",
  "ws_stream_wasm",
 ]
 
 [[package]]
 name = "graphql_client"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cdf7b487d864c2939b23902291a5041bc4a84418268f25fda1c8d4e15ad8fa"
+checksum = "a50cfdc7f34b7f01909d55c2dcb71d4c13cbcbb4a1605d6c8bd760d654c1144b"
 dependencies = [
  "graphql_query_derive",
  "serde",
@@ -1122,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "graphql_client_codegen"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40f793251171991c4eb75bd84bc640afa8b68ff6907bc89d3b712a22f700506"
+checksum = "5e27ed0c2cf0c0cc52c6bcf3b45c907f433015e580879d14005386251842fb0a"
 dependencies = [
  "graphql-introspection-query",
  "graphql-parser",
@@ -1139,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "graphql_query_derive"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bda454f3d313f909298f626115092d348bc231025699f557b27e248475f48c"
+checksum = "83febfa838f898cfa73dfaa7a8eb69ff3409021ac06ee94cfb3d622f6eeb1a97"
 dependencies = [
  "graphql_client_codegen",
  "proc-macro2",
@@ -2154,7 +2128,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -2254,6 +2228,24 @@ dependencies = [
  "sha1",
  "thiserror",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
  "utf-8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ serde_json = "1.0"
 thiserror = "1.0"
 
 cynic = { version = "3", optional = true }
-tungstenite = { version = "0.21", optional = true }
-graphql_client = { version = "0.13.0", optional = true }
+tungstenite = { version = "0.23", optional = true }
+graphql_client = { version = "0.14.0", optional = true }
 
 ws_stream_wasm = { version = "0.7", optional = true }
 pin-project-lite = { version = "0.2.7", optional = true }
@@ -48,7 +48,7 @@ futures-timer = "3.0.3"
 assert_matches = "1.5"
 async-graphql = "7.0.1"
 async-graphql-axum = "7"
-async-tungstenite = { version = "0.25", features = ["tokio-runtime"] }
+async-tungstenite = { version = "0.26", features = ["tokio-runtime"] }
 axum = "0.7"
 axum-macros = "0.4"
 cynic = { version = "3" }

--- a/examples-wasm/Cargo.toml
+++ b/examples-wasm/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 async-std = { version = "1.9", features = ["attributes"] }
-async_executors = { version = "0.5", features = ["async_std"] }
+async_executors = { version = "0.7", features = ["async_std"] }
 cynic = { version = "3" }
 futures = { version = "0.3"}
 log = "0.4"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 
 [dependencies]
 async-std = { version = "1.9", features = ["attributes"] }
-async-tungstenite = { version = "0.25", features = ["async-std-runtime", "tokio-runtime"] }
+async-tungstenite = { version = "0.26", features = ["async-std-runtime", "tokio-runtime"] }
 async_executors = { version = "0.7", features = ["async_std"] }
 cynic = { version = "3" }
 futures = { version = "0.3"}
-graphql_client = { version = "0.13" }
+graphql_client = { version = "0.14" }
 serde = "1"
 tokio = { version = "1.15", features = ["rt-multi-thread", "macros"] }
 


### PR DESCRIPTION
Fix #98 
Updated all dependencies to latest version:
- `tungstenite` from `0.21` to `0.23`
- `async-tungstenite` from `0.25` to `0.26`
- `graphql_client` from `0.13.0` to `0.14.0`
- `async_executors` from `0.5` to `0.7`