### PR TITLE
feat!: Connection functions now return impl Future

### DIFF
--- a/src/doc_utils.rs
+++ b/src/doc_utils.rs
@@ -1,15 +1,15 @@
-use std::{future::Future, pin::Pin};
+use std::future::Future;
 
 use crate::{next::Message, Error};
 
 pub struct Conn;
 
 impl crate::next::Connection for Conn {
-    fn receive(&mut self) -> Pin<Box<dyn Future<Output = Option<Message>> + Send + '_>> {
+    async fn receive(&mut self) -> Option<Message> {
         unimplemented!()
     }
 
-    fn send(&mut self, _: Message) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>> {
+    async fn send(&mut self, _: Message) -> Result<(), Error> {
         unimplemented!()
     }
 }

--- a/src/native.rs
+++ b/src/native.rs
@@ -1,6 +1,4 @@
-use std::{future::Future, pin::Pin};
-
-use futures::{future::BoxFuture, Sink, SinkExt};
+use futures::{Sink, SinkExt};
 use futures_lite::{Stream, StreamExt};
 use tungstenite::{self, protocol::CloseFrame};
 
@@ -16,55 +14,47 @@ where
         + Unpin,
     <T as Sink<tungstenite::Message>>::Error: std::fmt::Display,
 {
-    fn receive(&mut self) -> Pin<Box<dyn Future<Output = Option<Message>> + Send + '_>> {
-        Box::pin(async move {
-            loop {
-                match self.next().await? {
-                    Ok(tungstenite::Message::Text(text)) => {
-                        return Some(crate::next::Message::Text(text))
-                    }
-                    Ok(tungstenite::Message::Ping(_)) => return Some(crate::next::Message::Ping),
-                    Ok(tungstenite::Message::Pong(_)) => return Some(crate::next::Message::Pong),
-                    Ok(tungstenite::Message::Close(frame)) => {
-                        return Some(crate::next::Message::Close {
-                            code: frame.as_ref().map(|frame| frame.code.into()),
-                            reason: frame.map(|frame| frame.reason.to_string()),
-                        })
-                    }
-                    Ok(tungstenite::Message::Frame(_) | tungstenite::Message::Binary(_)) => {
-                        continue
-                    }
-                    Err(error) => {
-                        #[allow(unused)]
-                        let error = error;
-                        crate::logging::warning!("error receiving message: {error:?}");
-                        return None;
-                    }
+    async fn receive(&mut self) -> Option<Message> {
+        loop {
+            match self.next().await? {
+                Ok(tungstenite::Message::Text(text)) => {
+                    return Some(crate::next::Message::Text(text))
+                }
+                Ok(tungstenite::Message::Ping(_)) => return Some(crate::next::Message::Ping),
+                Ok(tungstenite::Message::Pong(_)) => return Some(crate::next::Message::Pong),
+                Ok(tungstenite::Message::Close(frame)) => {
+                    return Some(crate::next::Message::Close {
+                        code: frame.as_ref().map(|frame| frame.code.into()),
+                        reason: frame.map(|frame| frame.reason.to_string()),
+                    })
+                }
+                Ok(tungstenite::Message::Frame(_) | tungstenite::Message::Binary(_)) => continue,
+                Err(error) => {
+                    #[allow(unused)]
+                    let error = error;
+                    crate::logging::warning!("error receiving message: {error:?}");
+                    return None;
                 }
             }
-        })
+        }
     }
 
-    fn send(&mut self, message: crate::next::Message) -> BoxFuture<'_, Result<(), Error>> {
-        Box::pin(async move {
-            <Self as SinkExt<tungstenite::Message>>::send(
-                self,
-                match message {
-                    crate::next::Message::Text(text) => tungstenite::Message::Text(text),
-                    crate::next::Message::Close { code, reason } => {
-                        tungstenite::Message::Close(code.zip(reason).map(|(code, reason)| {
-                            CloseFrame {
-                                code: code.into(),
-                                reason: reason.into(),
-                            }
-                        }))
-                    }
-                    crate::next::Message::Ping => tungstenite::Message::Ping(vec![]),
-                    crate::next::Message::Pong => tungstenite::Message::Pong(vec![]),
-                },
-            )
-            .await
-            .map_err(|error| Error::Send(error.to_string()))
-        })
+    async fn send(&mut self, message: crate::next::Message) -> Result<(), Error> {
+        <Self as SinkExt<tungstenite::Message>>::send(
+            self,
+            match message {
+                crate::next::Message::Text(text) => tungstenite::Message::Text(text),
+                crate::next::Message::Close { code, reason } => {
+                    tungstenite::Message::Close(code.zip(reason).map(|(code, reason)| CloseFrame {
+                        code: code.into(),
+                        reason: reason.into(),
+                    }))
+                }
+                crate::next::Message::Ping => tungstenite::Message::Ping(vec![]),
+                crate::next::Message::Pong => tungstenite::Message::Pong(vec![]),
+            },
+        )
+        .await
+        .map_err(|error| Error::Send(error.to_string()))
     }
 }

--- a/src/next/actor.rs
+++ b/src/next/actor.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use super::{
-    connection::{Connection, Message},
+    connection::{Message, ObjectSafeConnection},
     keepalive::KeepAliveSettings,
     ConnectionCommand,
 };
@@ -26,7 +26,7 @@ use super::{
 /// with an async runtime.
 pub struct ConnectionActor {
     client: Option<async_channel::Receiver<ConnectionCommand>>,
-    connection: Box<dyn Connection + Send>,
+    connection: Box<dyn ObjectSafeConnection>,
     operations: HashMap<usize, async_channel::Sender<Value>>,
     keep_alive: KeepAliveSettings,
     keep_alive_actor: stream::Boxed<ConnectionCommand>,
@@ -34,7 +34,7 @@ pub struct ConnectionActor {
 
 impl ConnectionActor {
     pub(super) fn new(
-        connection: Box<dyn Connection + Send>,
+        connection: Box<dyn ObjectSafeConnection>,
         client: async_channel::Receiver<ConnectionCommand>,
         keep_alive: KeepAliveSettings,
     ) -> Self {

--- a/src/next/builder.rs
+++ b/src/next/builder.rs
@@ -10,7 +10,7 @@ use crate::{graphql::GraphqlOperation, logging::trace, protocol::Event, Error};
 
 use super::{
     actor::ConnectionActor,
-    connection::{Connection, Message},
+    connection::{Connection, Message, ObjectSafeConnection},
     keepalive::KeepAliveSettings,
     production_future::read_from_producer,
     Client, Subscription,
@@ -34,7 +34,7 @@ use super::{
 pub struct ClientBuilder {
     payload: Option<serde_json::Value>,
     subscription_buffer_size: Option<usize>,
-    connection: Box<dyn Connection + Send>,
+    connection: Box<dyn ObjectSafeConnection>,
     keep_alive: KeepAliveSettings,
 }
 


### PR DESCRIPTION
Now that the MSRV is > 1.75 we can start making use of return position impl trait.

We need to specify send bounds on the returned futures so we return an impl Trait, but it seems like rust is smart enough to allow us to use an actual async function in the implementations.