### PR TITLE
Fix pong messages to follow the graphql websocket protocol.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ all APIs might be changed.
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fixed ping responses not following the graphql-transport-ws protocol
+  ([#116](https://github.com/obmarg/graphql-ws-client/pull/116))
+
+### Contributors
+
+Thanks to the people who contributed to this release:
+
+- @vorporeal
+
 ## v0.10.1 - 2024-06-08
 
 ### Bug Fixes

--- a/src/next/actor.rs
+++ b/src/next/actor.rs
@@ -149,7 +149,7 @@ impl ConnectionActor {
                 None
             }
             Event::ConnectionAck { .. } => Some(Message::close(Reason::UnexpectedAck)),
-            Event::Ping { .. } => Some(Message::Pong),
+            Event::Ping { .. } => Some(Message::graphql_pong()),
             Event::Pong { .. } => None,
         }
     }


### PR DESCRIPTION
The graphql websocket protocol uses messages with the text opcode and payload `{"type": "ping"}`/`{"type": "pong"}` instead of using the ping and pong opcodes.

At present, `graphql-ws-client` interprets a text message with payload `{"type": "ping"}` but responds with a pong message.  This can lead to servers dropping the connection, due to receiving a message that doesn't conform with the `graphql-transport-ws` protocol (see: https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#ping).

`Message::graphql_pong()` is already used in [`ClientBuilder::build()`](https://github.com/obmarg/graphql-ws-client/blob/1233eb5c8473c1c402c6a9acf189b0dc28fbf395/src/next/builder.rs#L189-L191) to respond to any ping messages received during connection initialization, but it isn't used for pings received after a subscription has been established.

I discovered this when updating our codebase from `graphql-ws-client 0.6.0` to `graphql-ws-client 0.10.1`, and noticed that the server would respond with a close frame after our client responded to a server-sent ping frame.