### PR TITLE
Send graphql-transport-ws ping instead of websocket ping frame.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ all APIs might be changed.
 
 ## Unreleased
 
+### Bug Fixes
+
+- `graphql-transport-ws` ping messages are now sent, instead of websocket ping 
+  frames, when using the `KeepAliveSettings` ([#117](https://github.com/obmarg/graphql-ws-client/pull/117))
+
+### Contributors
+
+Thanks to the people who contributed to this release:
+
+- @szgupta
+
 ## v0.10.1 - 2024-06-08
 
 ### Bug Fixes

--- a/src/next/actor.rs
+++ b/src/next/actor.rs
@@ -96,7 +96,7 @@ impl ConnectionActor {
                 code: Some(code),
                 reason: Some(reason),
             }),
-            ConnectionCommand::Ping => Some(Message::Ping),
+            ConnectionCommand::Ping => Some(Message::graphql_ping()),
         }
     }
 

--- a/src/next/connection.rs
+++ b/src/next/connection.rs
@@ -59,6 +59,10 @@ impl Message {
         Self::Text(serde_json::to_string(&crate::protocol::Message::Pong::<()>).unwrap())
     }
 
+    pub(crate) fn graphql_ping() -> Self {
+        Self::Text(serde_json::to_string(&crate::protocol::Message::Ping::<()>).unwrap())
+    }
+
     pub(crate) fn complete(id: usize) -> Self {
         Self::Text(
             serde_json::to_string(&crate::protocol::Message::Complete::<()> { id: id.to_string() })

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -39,6 +39,8 @@ pub enum Message<'a, Operation> {
     Subscribe { id: String, payload: &'a Operation },
     #[serde(rename = "complete")]
     Complete { id: String },
+    #[serde(rename = "ping")]
+    Ping,
     #[serde(rename = "pong")]
     Pong,
 }


### PR DESCRIPTION
## Description
When using the new keepalive functionality, we noticed that the pings are sent as [websocket ping frames](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2) rather than as [graphql-transport-ws ping messages](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#ping).

Aside from conforming to the protocol, the sub-protocol ping messages should be used to support a heartbeat mechanism from browser (i.e. wasm) clients, where there isn't a concept of ping / pong frames. Specifically, setting a `KeepAliveSettings::interval` from a browser client does not do anything right now.

## Testing
Locally tested to confirm that the correct ping messages are now sent from browser clients (and that a gql-conforming server responds with the appropriate pong message).