### PR TITLE
legacy gql (graphql-ws) support

### DIFF
--- a/src/next/builder.rs
+++ b/src/next/builder.rs
@@ -195,6 +195,9 @@ impl ClientBuilder {
                             trace!("connection_ack received, handshake completed");
                             break;
                         }
+                        Event::KeepAlive { .. } => {
+                            continue;
+                        }
                         event => {
                             connection
                                 .send(Message::Close {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -59,6 +59,11 @@ pub enum Event {
         id: String,
         payload: Vec<serde_json::Value>,
     },
+    #[serde(rename = "connection_error")]
+    ConnectionError {
+        id: String,
+        payload: Vec<serde_json::Value>,
+    },
     #[serde(rename = "complete")]
     Complete { id: String },
     #[serde(rename = "connection_ack")]
@@ -67,26 +72,42 @@ pub enum Event {
     Ping { payload: Option<serde_json::Value> },
     #[serde(rename = "pong")]
     Pong { payload: Option<serde_json::Value> },
+    #[serde(rename = "ka")]
+    KeepAlive { payload: Option<serde_json::Value> },
+    #[serde(rename = "connection_keep_alive")]
+    ConnectionKeepAlive { payload: Option<serde_json::Value> },
+    #[serde(rename = "data")]
+    Data {
+        id: String,
+        payload: Option<serde_json::Value>,
+    },
 }
 
 impl Event {
     pub fn id(&self) -> Option<&str> {
         match self {
-            Event::Next { id, .. } | Event::Complete { id, .. } | Event::Error { id, .. } => {
-                Some(id.as_ref())
-            }
+            Event::Next { id, .. }
+            | Event::Data { id, .. }
+            | Event::Complete { id, .. }
+            | Event::Error { id, .. }
+            | Event::ConnectionError { id, .. } => Some(id.as_ref()),
             Event::Ping { .. } | Event::Pong { .. } | Event::ConnectionAck { .. } => None,
+            Event::KeepAlive { .. } | Event::ConnectionKeepAlive { .. } => None,
         }
     }
 
     pub fn r#type(&self) -> &'static str {
         match self {
             Event::Next { .. } => "next",
+            Event::Data { .. } => "data",
             Event::Complete { .. } => "complete",
             Event::Error { .. } => "error",
+            Event::ConnectionError { .. } => "connection_error",
             Event::Ping { .. } => "ping",
             Event::Pong { .. } => "pong",
             Event::ConnectionAck { .. } => "connection_ack",
+            Event::KeepAlive { .. } => "ka",
+            Event::ConnectionKeepAlive { .. } => "connection_keep_alive",
         }
     }
 }


### PR DESCRIPTION
I'm not sure if you want to support legacy gql (graphql-ws protocol) events , if not I can maintain a fork. We're currently using Hasura, a graphql layer, which only uses the legacy gql protocol so this is a necessity for us.

This PR also includes the option to allow params on the connection_init event. This is necessary when needing to set an authorization header. Example:

```rust
#[derive(Serialize)]
struct AuthHeaders {
    #[serde(rename = "Authorization")]
    authorization: String,
}

#[derive(Serialize)]
struct AuthPayload {
    headers: AuthHeaders,
}

    let auth_payload = serde_json::to_value(&AuthPayload {
        headers: AuthHeaders {
            authorization: format!("Bearer {}", token),
        },
    })?;

    let (client, actor) = Client::build(connection, Some(auth_payload)).await?;
```

This is a breaking change in the sense that anyone using Client::build will now need to pass an optional payload as a second param. I'm fairly new to rust so if there is a more idiomatic way to do this w/out causing a breaking change lmk!