### PR TITLE
Expose Subscription::id, add Client.stop(subscription_id)

### DIFF
--- a/src/next/mod.rs
+++ b/src/next/mod.rs
@@ -113,6 +113,18 @@ impl Client {
         })
     }
 
+    /// Stops a subscription by id by sending a Complete message to the server.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if the stop operation fails.
+    pub async fn stop(self, subscription_id: usize) -> Result<(), Error> {
+        self.actor
+            .send(ConnectionCommand::Cancel(subscription_id))
+            .await
+            .map_err(|error| Error::Send(error.to_string()))
+    }
+
     /// Gracefully closes the connection
     ///
     /// This will stop all running subscriptions and shut down the [`ConnectionActor`] wherever

--- a/src/next/stream.rs
+++ b/src/next/stream.rs
@@ -17,7 +17,8 @@ pub struct Subscription<Operation>
 where
     Operation: GraphqlOperation,
 {
-    pub(super) id: usize,
+    /// The ID of the subscription.
+    pub id: usize,
     pub(super) stream: stream::Boxed<Result<Operation::Response, Error>>,
     pub(super) actor: async_channel::Sender<ConnectionCommand>,
 }


### PR DESCRIPTION
I'd like to be able to manage a list of subscriptions on a connection to be able to stop a subscription easily. Currently with a list of `Subscription` type items, is difficult/complex mange them in a Map or Vec due to the generics. I couldn't figure out how to box them when I am creating different subscription types on the same connection.

Instead, just exposing `Subscription::id` allows you to cancel the subscription by id on the client itself which makes it so you do not have to worry about request types at all, since I just would need to manage the `usize` id for the subscription.