### PR TITLE
feat: expose ConnectionId newtype

### DIFF
--- a/src/client/conection_id.rs
+++ b/src/client/conection_id.rs
@@ -1,0 +1,23 @@
+use std::num::NonZero;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+/// An opaque identifier for a subscription
+///
+/// Currently this wraps a `NonZero<usize>` though that may be subject to change
+/// in the future - as a result the underlying type is not exposed publically
+pub struct SubscriptionId(NonZero<usize>);
+
+impl SubscriptionId {
+    pub(super) fn new(id: usize) -> Option<Self> {
+        Some(SubscriptionId(NonZero::new(id)?))
+    }
+
+    #[expect(clippy::inherent_to_string)] // Don't want this to be public, which implementing Display would make it.
+    pub(super) fn to_string(self) -> String {
+        self.0.to_string()
+    }
+
+    pub(super) fn from_str(s: &str) -> Option<Self> {
+        SubscriptionId::new(s.parse::<usize>().ok()?)
+    }
+}

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::Error;
+use crate::{Error, SubscriptionId};
 
 /// Abstraction around a websocket connection.
 ///
@@ -63,7 +63,7 @@ impl Message {
         Self::Text(serde_json::to_string(&crate::protocol::Message::Ping::<()>).unwrap())
     }
 
-    pub(crate) fn complete(id: usize) -> Self {
+    pub(crate) fn complete(id: SubscriptionId) -> Self {
         Self::Text(
             serde_json::to_string(&crate::protocol::Message::Complete::<()> { id: id.to_string() })
                 .unwrap(),

--- a/src/client/stream.rs
+++ b/src/client/stream.rs
@@ -5,7 +5,9 @@ use std::{
 
 use futures_lite::{future, stream, Stream, StreamExt};
 
-use crate::{client::production_future::read_from_producer, graphql::GraphqlOperation, Error};
+use crate::{
+    client::production_future::read_from_producer, graphql::GraphqlOperation, Error, SubscriptionId,
+};
 
 use super::ConnectionCommand;
 
@@ -17,10 +19,10 @@ pub struct Subscription<Operation>
 where
     Operation: GraphqlOperation,
 {
-    pub(in crate::client) id: usize,
+    pub(in crate::client) id: SubscriptionId,
     pub(in crate::client) stream: Option<stream::Boxed<Result<Operation::Response, Error>>>,
     pub(in crate::client) actor: async_channel::Sender<ConnectionCommand>,
-    pub(in crate::client) drop_sender: async_channel::Sender<usize>,
+    pub(in crate::client) drop_sender: async_channel::Sender<SubscriptionId>,
 }
 
 #[pin_project::pinned_drop]

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,4 +25,10 @@ pub enum Error {
     /// Sender shutdown error
     #[error("sender shutdown error, reason: {0}")]
     SenderShutdown(String),
+    /// Too many existing connections have been created.
+    ///
+    /// Note that this would require a usize to be exhausted so is quite
+    /// unlikely
+    #[error("connection ID space exhausted.  please restart the client")]
+    ConnectionIdsExhausted,
 }


### PR DESCRIPTION
This will allow us to expose a `fn stop(SubscriptionId)` on the Client.